### PR TITLE
v1.10

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,9 @@
-1.10	2016-12-25
-		- 
+1.10	2016-12-28
+		- Usage of Lazy::Utils::fileCache instead of cache function
+		- Perl arguement fix ( -- ) in configuration, readme, pod
+		- Supervisor worker status fix for "no such ..." result for undefined workers
+		- Added file cache in Supervisor getStatuses
+		- Fix and changes for disk ioutil
 
 1.09	2016-12-23
 		- zbxEncode comma and nonascii fix

--- a/Changes
+++ b/Changes
@@ -1,3 +1,6 @@
+1.10	2016-12-25
+		- 
+
 1.09	2016-12-23
 		- zbxEncode comma and nonascii fix
 		- Fix in Time.pm for _ntp_offset returning scientific notation

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -15,7 +15,7 @@ WriteMakefile(
 		'File::Slurp' => 0,
 		'JSON' => 0,
 		'Net::NTP' => 0,
-		'Lazy::Utils' => '1.02',
+		'Lazy::Utils' => '1.04',
 	},
 	EXE_FILES			=> [qw(
 	)],

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -20,7 +20,7 @@ WriteMakefile(
 	EXE_FILES			=> [qw(
 	)],
 	AUTHOR				=> 'Orkun Karaduman <orkunkaraduman@gmail.com>',
-	ABSTRACT			=> 'System and service checks for Zabbix Agent',
+	ABSTRACT			=> 'System and service checks for Zabbix',
 	LICENSE				=> 'gpl_3',
 	META_MERGE			=> {
 		'meta-spec' => {

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -20,7 +20,7 @@ WriteMakefile(
 	EXE_FILES			=> [qw(
 	)],
 	AUTHOR				=> 'Orkun Karaduman <orkunkaraduman@gmail.com>',
-	ABSTRACT			=> 'Zabbix Agent system and service checks',
+	ABSTRACT			=> 'System and service checks for Zabbix Agent',
 	LICENSE				=> 'gpl_3',
 	META_MERGE			=> {
 		'meta-spec' => {

--- a/README
+++ b/README
@@ -103,7 +103,7 @@ SYNOPSIS
 
             UserParameter=cpan.zabbix.check.systemd.installed,/usr/bin/perl -MZabbix::Check::Systemd -e_installed
             UserParameter=cpan.zabbix.check.systemd.system_status,/usr/bin/perl -MZabbix::Check::Systemd -e_system_status
-            UserParameter=cpan.zabbix.check.systemd.service_discovery,/usr/bin/perl -MZabbix::Check::Systemd -e_service_discovery
+            UserParameter=cpan.zabbix.check.systemd.service_discovery[*],/usr/bin/perl -MZabbix::Check::Systemd -e_service_discovery -- $1
             UserParameter=cpan.zabbix.check.systemd.service_status[*],/usr/bin/perl -MZabbix::Check::Systemd -e_service_status -- $1
 
    installed
@@ -115,6 +115,8 @@ SYNOPSIS
 
    service_discovery
     discovers Systemd enabled services
+
+    $1: *regex of service name, by default undefined*
 
    service_status $1
     gets Systemd enabled service status: active | inactive | failed |

--- a/README
+++ b/README
@@ -1,11 +1,11 @@
 NAME
-    Zabbix::Check - Zabbix Agent system and service checks
+    Zabbix::Check - System and service checks for Zabbix
 
 VERSION
     version 1.10
 
 SYNOPSIS
-    System and service checks for Zabbix Agent
+    System and service checks for Zabbix
 
             UserParameter=cpan.zabbix.check.version,/usr/bin/perl -MZabbix::Check -e_version
 

--- a/README
+++ b/README
@@ -5,7 +5,7 @@ VERSION
     version 1.10
 
 SYNOPSIS
-    Zabbix Agent system and service checks
+    System and service checks for Zabbix Agent
 
             UserParameter=cpan.zabbix.check.version,/usr/bin/perl -MZabbix::Check -e_version
 

--- a/README
+++ b/README
@@ -16,9 +16,9 @@ SYNOPSIS
     Zabbix check for disk
 
             UserParameter=cpan.zabbix.check.disk.discovery,/usr/bin/perl -MZabbix::Check::Disk -e_discovery
-            UserParameter=cpan.zabbix.check.disk.bps[*],/usr/bin/perl -MZabbix::Check::Disk -e_bps $1 $2
-            UserParameter=cpan.zabbix.check.disk.iops[*],/usr/bin/perl -MZabbix::Check::Disk -e_iops $1 $2
-            UserParameter=cpan.zabbix.check.disk.ioutil[*],/usr/bin/perl -MZabbix::Check::Disk -e_ioutil $1 $2
+            UserParameter=cpan.zabbix.check.disk.bps[*],/usr/bin/perl -MZabbix::Check::Disk -e_bps -- $1 $2
+            UserParameter=cpan.zabbix.check.disk.iops[*],/usr/bin/perl -MZabbix::Check::Disk -e_iops -- $1 $2
+            UserParameter=cpan.zabbix.check.disk.ioutil[*],/usr/bin/perl -MZabbix::Check::Disk -e_ioutil -- $1 $2
 
    discovery
     discovers disks
@@ -50,7 +50,7 @@ SYNOPSIS
             UserParameter=cpan.zabbix.check.supervisor.installed,/usr/bin/perl -MZabbix::Check::Supervisor -e_installed
             UserParameter=cpan.zabbix.check.supervisor.running,/usr/bin/perl -MZabbix::Check::Supervisor -e_running
             UserParameter=cpan.zabbix.check.supervisor.worker_discovery,/usr/bin/perl -MZabbix::Check::Supervisor -e_worker_discovery
-            UserParameter=cpan.zabbix.check.supervisor.worker_status[*],/usr/bin/perl -MZabbix::Check::Supervisor -e_worker_status $1
+            UserParameter=cpan.zabbix.check.supervisor.worker_status[*],/usr/bin/perl -MZabbix::Check::Supervisor -e_worker_status -- $1
 
    installed
     checks Supervisor is installed: 0 | 1
@@ -71,9 +71,9 @@ SYNOPSIS
 
             UserParameter=cpan.zabbix.check.rabbitmq.installed,/usr/bin/perl -MZabbix::Check::RabbitMQ -e_installed
             UserParameter=cpan.zabbix.check.rabbitmq.running,/usr/bin/perl -MZabbix::Check::RabbitMQ -e_running
-            UserParameter=cpan.zabbix.check.rabbitmq.vhost_discovery[*],/usr/bin/perl -MZabbix::Check::RabbitMQ -e_vhost_discovery $1
-            UserParameter=cpan.zabbix.check.rabbitmq.queue_discovery[*],/usr/bin/perl -MZabbix::Check::RabbitMQ -e_queue_discovery $1
-            UserParameter=cpan.zabbix.check.rabbitmq.queue_status[*],/usr/bin/perl -MZabbix::Check::RabbitMQ -e_queue_status $1 $2 $3
+            UserParameter=cpan.zabbix.check.rabbitmq.vhost_discovery[*],/usr/bin/perl -MZabbix::Check::RabbitMQ -e_vhost_discovery -- $1
+            UserParameter=cpan.zabbix.check.rabbitmq.queue_discovery[*],/usr/bin/perl -MZabbix::Check::RabbitMQ -e_queue_discovery -- $1
+            UserParameter=cpan.zabbix.check.rabbitmq.queue_status[*],/usr/bin/perl -MZabbix::Check::RabbitMQ -e_queue_status -- $1 $2 $3
 
    installed
     checks RabbitMQ is installed: 0 | 1
@@ -106,7 +106,7 @@ SYNOPSIS
             UserParameter=cpan.zabbix.check.systemd.installed,/usr/bin/perl -MZabbix::Check::Systemd -e_installed
             UserParameter=cpan.zabbix.check.systemd.system_status,/usr/bin/perl -MZabbix::Check::Systemd -e_system_status
             UserParameter=cpan.zabbix.check.systemd.service_discovery,/usr/bin/perl -MZabbix::Check::Systemd -e_service_discovery
-            UserParameter=cpan.zabbix.check.systemd.service_status[*],/usr/bin/perl -MZabbix::Check::Systemd -e_service_status $1
+            UserParameter=cpan.zabbix.check.systemd.service_status[*],/usr/bin/perl -MZabbix::Check::Systemd -e_service_status -- $1
 
    installed
     checks Systemd is installed: 0 | 1
@@ -129,7 +129,7 @@ SYNOPSIS
 
             UserParameter=cpan.zabbix.check.time.epoch,/usr/bin/perl -MZabbix::Check::Time -e_epoch
             UserParameter=cpan.zabbix.check.time.zone,/usr/bin/perl -MZabbix::Check::Time -e_zone
-            UserParameter=cpan.zabbix.check.time.ntp_offset[*],/usr/bin/perl -MZabbix::Check::Time -e_ntp_offset $1 $2
+            UserParameter=cpan.zabbix.check.time.ntp_offset[*],/usr/bin/perl -MZabbix::Check::Time -e_ntp_offset -- $1 $2
 
    epoch
     gets system time epoch in seconds

--- a/README
+++ b/README
@@ -18,7 +18,7 @@ SYNOPSIS
             UserParameter=cpan.zabbix.check.disk.discovery,/usr/bin/perl -MZabbix::Check::Disk -e_discovery
             UserParameter=cpan.zabbix.check.disk.bps[*],/usr/bin/perl -MZabbix::Check::Disk -e_bps -- $1 $2
             UserParameter=cpan.zabbix.check.disk.iops[*],/usr/bin/perl -MZabbix::Check::Disk -e_iops -- $1 $2
-            UserParameter=cpan.zabbix.check.disk.ioutil[*],/usr/bin/perl -MZabbix::Check::Disk -e_ioutil -- $1 $2
+            UserParameter=cpan.zabbix.check.disk.ioutil[*],/usr/bin/perl -MZabbix::Check::Disk -e_ioutil -- $1
 
    discovery
     discovers disks
@@ -41,8 +41,6 @@ SYNOPSIS
     gets disk I/O utilization in percentage
 
     $1: *device name, eg: sda, sdb1, dm-3, ...*
-
-    $2: *type: read|write|total*
 
   Supervisor
     Zabbix check for Supervisor service

--- a/README
+++ b/README
@@ -2,7 +2,7 @@ NAME
     Zabbix::Check - Zabbix Agent system and service checks
 
 VERSION
-    version 1.09
+    version 1.10
 
 SYNOPSIS
     Zabbix Agent system and service checks

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Zabbix check for Systemd services
 
         UserParameter=cpan.zabbix.check.systemd.installed,/usr/bin/perl -MZabbix::Check::Systemd -e_installed
         UserParameter=cpan.zabbix.check.systemd.system_status,/usr/bin/perl -MZabbix::Check::Systemd -e_system_status
-        UserParameter=cpan.zabbix.check.systemd.service_discovery,/usr/bin/perl -MZabbix::Check::Systemd -e_service_discovery
+        UserParameter=cpan.zabbix.check.systemd.service_discovery[*],/usr/bin/perl -MZabbix::Check::Systemd -e_service_discovery -- $1
         UserParameter=cpan.zabbix.check.systemd.service_status[*],/usr/bin/perl -MZabbix::Check::Systemd -e_service_status -- $1
 
 ### installed
@@ -138,6 +138,8 @@ gets Systemd system status: initializing | starting | running | degraded | maint
 ### service\_discovery
 
 discovers Systemd enabled services
+
+$1: _regex of service name, by default undefined_
 
 ### service\_status $1
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ version 1.10
 
 # SYNOPSIS
 
-Zabbix Agent system and service checks
+System and service checks for Zabbix Agent
 
         UserParameter=cpan.zabbix.check.version,/usr/bin/perl -MZabbix::Check -e_version
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Zabbix check for disk
         UserParameter=cpan.zabbix.check.disk.discovery,/usr/bin/perl -MZabbix::Check::Disk -e_discovery
         UserParameter=cpan.zabbix.check.disk.bps[*],/usr/bin/perl -MZabbix::Check::Disk -e_bps -- $1 $2
         UserParameter=cpan.zabbix.check.disk.iops[*],/usr/bin/perl -MZabbix::Check::Disk -e_iops -- $1 $2
-        UserParameter=cpan.zabbix.check.disk.ioutil[*],/usr/bin/perl -MZabbix::Check::Disk -e_ioutil -- $1 $2
+        UserParameter=cpan.zabbix.check.disk.ioutil[*],/usr/bin/perl -MZabbix::Check::Disk -e_ioutil -- $1
 
 ### discovery
 
@@ -50,8 +50,6 @@ $2: _type: read|write|total_
 gets disk I/O utilization in percentage
 
 $1: _device name, eg: sda, sdb1, dm-3, ..._
-
-$2: _type: read|write|total_
 
 ## Supervisor
 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ gets Zabbix::Check version
 Zabbix check for disk
 
         UserParameter=cpan.zabbix.check.disk.discovery,/usr/bin/perl -MZabbix::Check::Disk -e_discovery
-        UserParameter=cpan.zabbix.check.disk.bps[*],/usr/bin/perl -MZabbix::Check::Disk -e_bps $1 $2
-        UserParameter=cpan.zabbix.check.disk.iops[*],/usr/bin/perl -MZabbix::Check::Disk -e_iops $1 $2
-        UserParameter=cpan.zabbix.check.disk.ioutil[*],/usr/bin/perl -MZabbix::Check::Disk -e_ioutil $1 $2
+        UserParameter=cpan.zabbix.check.disk.bps[*],/usr/bin/perl -MZabbix::Check::Disk -e_bps -- $1 $2
+        UserParameter=cpan.zabbix.check.disk.iops[*],/usr/bin/perl -MZabbix::Check::Disk -e_iops -- $1 $2
+        UserParameter=cpan.zabbix.check.disk.ioutil[*],/usr/bin/perl -MZabbix::Check::Disk -e_ioutil -- $1 $2
 
 ### discovery
 
@@ -60,7 +60,7 @@ Zabbix check for Supervisor service
         UserParameter=cpan.zabbix.check.supervisor.installed,/usr/bin/perl -MZabbix::Check::Supervisor -e_installed
         UserParameter=cpan.zabbix.check.supervisor.running,/usr/bin/perl -MZabbix::Check::Supervisor -e_running
         UserParameter=cpan.zabbix.check.supervisor.worker_discovery,/usr/bin/perl -MZabbix::Check::Supervisor -e_worker_discovery
-        UserParameter=cpan.zabbix.check.supervisor.worker_status[*],/usr/bin/perl -MZabbix::Check::Supervisor -e_worker_status $1
+        UserParameter=cpan.zabbix.check.supervisor.worker_status[*],/usr/bin/perl -MZabbix::Check::Supervisor -e_worker_status -- $1
 
 ### installed
 
@@ -86,9 +86,9 @@ Zabbix check for RabbitMQ service
 
         UserParameter=cpan.zabbix.check.rabbitmq.installed,/usr/bin/perl -MZabbix::Check::RabbitMQ -e_installed
         UserParameter=cpan.zabbix.check.rabbitmq.running,/usr/bin/perl -MZabbix::Check::RabbitMQ -e_running
-        UserParameter=cpan.zabbix.check.rabbitmq.vhost_discovery[*],/usr/bin/perl -MZabbix::Check::RabbitMQ -e_vhost_discovery $1
-        UserParameter=cpan.zabbix.check.rabbitmq.queue_discovery[*],/usr/bin/perl -MZabbix::Check::RabbitMQ -e_queue_discovery $1
-        UserParameter=cpan.zabbix.check.rabbitmq.queue_status[*],/usr/bin/perl -MZabbix::Check::RabbitMQ -e_queue_status $1 $2 $3
+        UserParameter=cpan.zabbix.check.rabbitmq.vhost_discovery[*],/usr/bin/perl -MZabbix::Check::RabbitMQ -e_vhost_discovery -- $1
+        UserParameter=cpan.zabbix.check.rabbitmq.queue_discovery[*],/usr/bin/perl -MZabbix::Check::RabbitMQ -e_queue_discovery -- $1
+        UserParameter=cpan.zabbix.check.rabbitmq.queue_status[*],/usr/bin/perl -MZabbix::Check::RabbitMQ -e_queue_status -- $1 $2 $3
 
 ### installed
 
@@ -127,7 +127,7 @@ Zabbix check for Systemd services
         UserParameter=cpan.zabbix.check.systemd.installed,/usr/bin/perl -MZabbix::Check::Systemd -e_installed
         UserParameter=cpan.zabbix.check.systemd.system_status,/usr/bin/perl -MZabbix::Check::Systemd -e_system_status
         UserParameter=cpan.zabbix.check.systemd.service_discovery,/usr/bin/perl -MZabbix::Check::Systemd -e_service_discovery
-        UserParameter=cpan.zabbix.check.systemd.service_status[*],/usr/bin/perl -MZabbix::Check::Systemd -e_service_status $1
+        UserParameter=cpan.zabbix.check.systemd.service_status[*],/usr/bin/perl -MZabbix::Check::Systemd -e_service_status -- $1
 
 ### installed
 
@@ -153,7 +153,7 @@ Zabbix check for system time
 
         UserParameter=cpan.zabbix.check.time.epoch,/usr/bin/perl -MZabbix::Check::Time -e_epoch
         UserParameter=cpan.zabbix.check.time.zone,/usr/bin/perl -MZabbix::Check::Time -e_zone
-        UserParameter=cpan.zabbix.check.time.ntp_offset[*],/usr/bin/perl -MZabbix::Check::Time -e_ntp_offset $1 $2
+        UserParameter=cpan.zabbix.check.time.ntp_offset[*],/usr/bin/perl -MZabbix::Check::Time -e_ntp_offset -- $1 $2
 
 ### epoch
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NAME
 
-Zabbix::Check - Zabbix Agent system and service checks
+Zabbix::Check - System and service checks for Zabbix
 
 # VERSION
 
@@ -8,7 +8,7 @@ version 1.10
 
 # SYNOPSIS
 
-System and service checks for Zabbix Agent
+System and service checks for Zabbix
 
         UserParameter=cpan.zabbix.check.version,/usr/bin/perl -MZabbix::Check -e_version
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Zabbix::Check - Zabbix Agent system and service checks
 
 # VERSION
 
-version 1.09
+version 1.10
 
 # SYNOPSIS
 

--- a/conf/Template CPAN Zabbix-Check.xml
+++ b/conf/Template CPAN Zabbix-Check.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export>
     <version>3.0</version>
-    <date>2016-12-27T12:56:22Z</date>
+    <date>2016-12-27T13:56:59Z</date>
     <groups>
         <group>
             <name>Templates</name>
@@ -342,7 +342,7 @@
                     <snmp_community/>
                     <multiplier>0</multiplier>
                     <snmp_oid/>
-                    <key>cpan.zabbix.check.time.ntp_offset[{$TIME_NTP_SERVER}]</key>
+                    <key>cpan.zabbix.check.time.ntp_offset[{$ZC_TIME_NTP_SERVER}]</key>
                     <delay>60</delay>
                     <history>7</history>
                     <trends>365</trends>
@@ -507,7 +507,7 @@
                             <multiplier>0</multiplier>
                             <snmp_oid/>
                             <key>cpan.zabbix.check.disk.bps[{#DEVNAME},read]</key>
-                            <delay>30</delay>
+                            <delay>60</delay>
                             <history>7</history>
                             <trends>365</trends>
                             <status>0</status>
@@ -547,7 +547,7 @@
                             <multiplier>0</multiplier>
                             <snmp_oid/>
                             <key>cpan.zabbix.check.disk.bps[{#DEVNAME},total]</key>
-                            <delay>30</delay>
+                            <delay>60</delay>
                             <history>7</history>
                             <trends>365</trends>
                             <status>0</status>
@@ -587,7 +587,7 @@
                             <multiplier>0</multiplier>
                             <snmp_oid/>
                             <key>cpan.zabbix.check.disk.bps[{#DEVNAME},write]</key>
-                            <delay>30</delay>
+                            <delay>60</delay>
                             <history>7</history>
                             <trends>365</trends>
                             <status>0</status>
@@ -627,7 +627,7 @@
                             <multiplier>0</multiplier>
                             <snmp_oid/>
                             <key>cpan.zabbix.check.disk.iops[{#DEVNAME},read]</key>
-                            <delay>30</delay>
+                            <delay>60</delay>
                             <history>7</history>
                             <trends>365</trends>
                             <status>0</status>
@@ -667,7 +667,7 @@
                             <multiplier>0</multiplier>
                             <snmp_oid/>
                             <key>cpan.zabbix.check.disk.iops[{#DEVNAME},total]</key>
-                            <delay>30</delay>
+                            <delay>60</delay>
                             <history>7</history>
                             <trends>365</trends>
                             <status>0</status>
@@ -707,7 +707,7 @@
                             <multiplier>0</multiplier>
                             <snmp_oid/>
                             <key>cpan.zabbix.check.disk.iops[{#DEVNAME},write]</key>
-                            <delay>30</delay>
+                            <delay>60</delay>
                             <history>7</history>
                             <trends>365</trends>
                             <status>0</status>
@@ -747,7 +747,7 @@
                             <multiplier>0</multiplier>
                             <snmp_oid/>
                             <key>cpan.zabbix.check.disk.ioutil[{#DEVNAME},read]</key>
-                            <delay>30</delay>
+                            <delay>60</delay>
                             <history>7</history>
                             <trends>365</trends>
                             <status>0</status>
@@ -787,7 +787,7 @@
                             <multiplier>0</multiplier>
                             <snmp_oid/>
                             <key>cpan.zabbix.check.disk.ioutil[{#DEVNAME},total]</key>
-                            <delay>30</delay>
+                            <delay>60</delay>
                             <history>7</history>
                             <trends>365</trends>
                             <status>0</status>
@@ -827,7 +827,7 @@
                             <multiplier>0</multiplier>
                             <snmp_oid/>
                             <key>cpan.zabbix.check.disk.ioutil[{#DEVNAME},write]</key>
-                            <delay>30</delay>
+                            <delay>60</delay>
                             <history>7</history>
                             <trends>365</trends>
                             <status>0</status>
@@ -1105,7 +1105,7 @@
                             <multiplier>0</multiplier>
                             <snmp_oid/>
                             <key>cpan.zabbix.check.rabbitmq.queue_status[{#VHOST},{#QUEUE},ready]</key>
-                            <delay>60</delay>
+                            <delay>600</delay>
                             <history>7</history>
                             <trends>365</trends>
                             <status>0</status>
@@ -1149,7 +1149,7 @@
                             <multiplier>0</multiplier>
                             <snmp_oid/>
                             <key>cpan.zabbix.check.rabbitmq.queue_status[{#VHOST},{#QUEUE},total]</key>
-                            <delay>60</delay>
+                            <delay>600</delay>
                             <history>7</history>
                             <trends>365</trends>
                             <status>0</status>
@@ -1193,7 +1193,7 @@
                             <multiplier>0</multiplier>
                             <snmp_oid/>
                             <key>cpan.zabbix.check.rabbitmq.queue_status[{#VHOST},{#QUEUE},unacked]</key>
-                            <delay>60</delay>
+                            <delay>600</delay>
                             <history>7</history>
                             <trends>365</trends>
                             <status>0</status>
@@ -1668,15 +1668,15 @@
             </discovery_rules>
             <macros>
                 <macro>
-                    <macro>{$TIME_NTP_OFFSET}</macro>
+                    <macro>{$ZC_TIME_NTP_OFFSET}</macro>
                     <value>15</value>
                 </macro>
                 <macro>
-                    <macro>{$TIME_NTP_SERVER}</macro>
+                    <macro>{$ZC_TIME_NTP_SERVER}</macro>
                     <value>pool.ntp.org</value>
                 </macro>
                 <macro>
-                    <macro>{$TIME_ZONE}</macro>
+                    <macro>{$ZC_TIME_ZONE}</macro>
                     <value>+0000</value>
                 </macro>
             </macros>
@@ -1728,10 +1728,10 @@ and&#13;
             <dependencies/>
         </trigger>
         <trigger>
-            <expression>{CPAN Zabbix-Check:cpan.zabbix.check.time.ntp_offset[{$TIME_NTP_SERVER}].last()} &gt; {$TIME_NTP_OFFSET}&#13;
+            <expression>{CPAN Zabbix-Check:cpan.zabbix.check.time.ntp_offset[{$ZC_TIME_NTP_SERVER}].last()} &gt; {$ZC_TIME_NTP_OFFSET}&#13;
 or&#13;
-{CPAN Zabbix-Check:cpan.zabbix.check.time.ntp_offset[{$TIME_NTP_SERVER}].last()} &lt; -{$TIME_NTP_OFFSET}</expression>
-            <name>Time NTP offset too high (&gt;{$TIME_NTP_OFFSET}s)</name>
+{CPAN Zabbix-Check:cpan.zabbix.check.time.ntp_offset[{$ZC_TIME_NTP_SERVER}].last()} &lt; -{$ZC_TIME_NTP_OFFSET}</expression>
+            <name>Time NTP offset too high (&gt;{$ZC_TIME_NTP_OFFSET}s)</name>
             <url/>
             <status>0</status>
             <priority>3</priority>
@@ -1740,7 +1740,7 @@ or&#13;
             <dependencies/>
         </trigger>
         <trigger>
-            <expression>{CPAN Zabbix-Check:cpan.zabbix.check.time.zone.iregexp(^\{$TIME_ZONE}$)} = 0</expression>
+            <expression>{CPAN Zabbix-Check:cpan.zabbix.check.time.zone.iregexp(^\{$ZC_TIME_ZONE}$)} = 0</expression>
             <name>Time zone wrong</name>
             <url/>
             <status>0</status>
@@ -1778,7 +1778,7 @@ or&#13;
                     <type>0</type>
                     <item>
                         <host>CPAN Zabbix-Check</host>
-                        <key>cpan.zabbix.check.time.ntp_offset[{$TIME_NTP_SERVER}]</key>
+                        <key>cpan.zabbix.check.time.ntp_offset[{$ZC_TIME_NTP_SERVER}]</key>
                     </item>
                 </graph_item>
             </graph_items>

--- a/conf/Template CPAN Zabbix-Check.xml
+++ b/conf/Template CPAN Zabbix-Check.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export>
     <version>3.0</version>
-    <date>2016-12-28T06:19:40Z</date>
+    <date>2016-12-28T11:03:46Z</date>
     <groups>
         <group>
             <name>Templates</name>
@@ -1565,7 +1565,7 @@
                             <graph_items>
                                 <graph_item>
                                     <sortorder>0</sortorder>
-                                    <drawtype>0</drawtype>
+                                    <drawtype>2</drawtype>
                                     <color>00C800</color>
                                     <yaxisside>0</yaxisside>
                                     <calc_fnc>2</calc_fnc>
@@ -1578,7 +1578,7 @@
                                 <graph_item>
                                     <sortorder>1</sortorder>
                                     <drawtype>0</drawtype>
-                                    <color>C80000</color>
+                                    <color>0000C8</color>
                                     <yaxisside>0</yaxisside>
                                     <calc_fnc>2</calc_fnc>
                                     <type>0</type>

--- a/conf/Template CPAN Zabbix-Check.xml
+++ b/conf/Template CPAN Zabbix-Check.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export>
     <version>3.0</version>
-    <date>2016-12-27T13:56:59Z</date>
+    <date>2016-12-28T06:19:40Z</date>
     <groups>
         <group>
             <name>Templates</name>
@@ -18,6 +18,9 @@
                 </group>
             </groups>
             <applications>
+                <application>
+                    <name>Disk</name>
+                </application>
                 <application>
                     <name>General</name>
                 </application>
@@ -535,7 +538,11 @@
                             <port/>
                             <description/>
                             <inventory_link>0</inventory_link>
-                            <applications/>
+                            <applications>
+                                <application>
+                                    <name>Disk</name>
+                                </application>
+                            </applications>
                             <valuemap/>
                             <logtimefmt/>
                             <application_prototypes/>
@@ -575,7 +582,11 @@
                             <port/>
                             <description/>
                             <inventory_link>0</inventory_link>
-                            <applications/>
+                            <applications>
+                                <application>
+                                    <name>Disk</name>
+                                </application>
+                            </applications>
                             <valuemap/>
                             <logtimefmt/>
                             <application_prototypes/>
@@ -615,7 +626,11 @@
                             <port/>
                             <description/>
                             <inventory_link>0</inventory_link>
-                            <applications/>
+                            <applications>
+                                <application>
+                                    <name>Disk</name>
+                                </application>
+                            </applications>
                             <valuemap/>
                             <logtimefmt/>
                             <application_prototypes/>
@@ -655,7 +670,11 @@
                             <port/>
                             <description/>
                             <inventory_link>0</inventory_link>
-                            <applications/>
+                            <applications>
+                                <application>
+                                    <name>Disk</name>
+                                </application>
+                            </applications>
                             <valuemap/>
                             <logtimefmt/>
                             <application_prototypes/>
@@ -695,7 +714,11 @@
                             <port/>
                             <description/>
                             <inventory_link>0</inventory_link>
-                            <applications/>
+                            <applications>
+                                <application>
+                                    <name>Disk</name>
+                                </application>
+                            </applications>
                             <valuemap/>
                             <logtimefmt/>
                             <application_prototypes/>
@@ -735,47 +758,11 @@
                             <port/>
                             <description/>
                             <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <application_prototypes/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>Disk {#DEVNAME} I/O Util read</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <multiplier>0</multiplier>
-                            <snmp_oid/>
-                            <key>cpan.zabbix.check.disk.ioutil[{#DEVNAME},read]</key>
-                            <delay>60</delay>
-                            <history>7</history>
-                            <trends>365</trends>
-                            <status>0</status>
-                            <value_type>0</value_type>
-                            <allowed_hosts/>
-                            <units>%</units>
-                            <delta>0</delta>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <data_type>0</data_type>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
+                            <applications>
+                                <application>
+                                    <name>Disk</name>
+                                </application>
+                            </applications>
                             <valuemap/>
                             <logtimefmt/>
                             <application_prototypes/>
@@ -786,7 +773,7 @@
                             <snmp_community/>
                             <multiplier>0</multiplier>
                             <snmp_oid/>
-                            <key>cpan.zabbix.check.disk.ioutil[{#DEVNAME},total]</key>
+                            <key>cpan.zabbix.check.disk.ioutil[{#DEVNAME}]</key>
                             <delay>60</delay>
                             <history>7</history>
                             <trends>365</trends>
@@ -815,47 +802,11 @@
                             <port/>
                             <description/>
                             <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                            <application_prototypes/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>Disk {#DEVNAME} I/O Util write</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <multiplier>0</multiplier>
-                            <snmp_oid/>
-                            <key>cpan.zabbix.check.disk.ioutil[{#DEVNAME},write]</key>
-                            <delay>60</delay>
-                            <history>7</history>
-                            <trends>365</trends>
-                            <status>0</status>
-                            <value_type>0</value_type>
-                            <allowed_hosts/>
-                            <units>%</units>
-                            <delta>0</delta>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <data_type>0</data_type>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
+                            <applications>
+                                <application>
+                                    <name>Disk</name>
+                                </application>
+                            </applications>
                             <valuemap/>
                             <logtimefmt/>
                             <application_prototypes/>
@@ -863,7 +814,7 @@
                     </item_prototypes>
                     <trigger_prototypes>
                         <trigger_prototype>
-                            <expression>{CPAN Zabbix-Check:cpan.zabbix.check.disk.ioutil[{#DEVNAME},total].last()} &gt; 90</expression>
+                            <expression>{CPAN Zabbix-Check:cpan.zabbix.check.disk.ioutil[{#DEVNAME}].last()} &gt; 90</expression>
                             <name>Disk {#DEVNAME} I/O Util too high(&gt;90%)</name>
                             <url/>
                             <status>0</status>
@@ -873,7 +824,7 @@
                             <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
-                            <expression>{CPAN Zabbix-Check:cpan.zabbix.check.disk.ioutil[{#DEVNAME},total].min(1m)} &gt; 90</expression>
+                            <expression>{CPAN Zabbix-Check:cpan.zabbix.check.disk.ioutil[{#DEVNAME}].min(1m)} &gt; 90</expression>
                             <name>Disk {#DEVNAME} I/O Util too high(&gt;90%) for 1m</name>
                             <url/>
                             <status>0</status>
@@ -883,7 +834,7 @@
                             <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
-                            <expression>{CPAN Zabbix-Check:cpan.zabbix.check.disk.ioutil[{#DEVNAME},total].min(15m)} &gt; 90</expression>
+                            <expression>{CPAN Zabbix-Check:cpan.zabbix.check.disk.ioutil[{#DEVNAME}].min(15m)} &gt; 90</expression>
                             <name>Disk {#DEVNAME} I/O Util too high(&gt;90%) for 15m</name>
                             <url/>
                             <status>0</status>
@@ -914,8 +865,8 @@
                             <graph_items>
                                 <graph_item>
                                     <sortorder>0</sortorder>
-                                    <drawtype>0</drawtype>
-                                    <color>00C800</color>
+                                    <drawtype>2</drawtype>
+                                    <color>C80000</color>
                                     <yaxisside>0</yaxisside>
                                     <calc_fnc>2</calc_fnc>
                                     <type>0</type>
@@ -927,7 +878,7 @@
                                 <graph_item>
                                     <sortorder>1</sortorder>
                                     <drawtype>0</drawtype>
-                                    <color>0000C8</color>
+                                    <color>00C800</color>
                                     <yaxisside>0</yaxisside>
                                     <calc_fnc>2</calc_fnc>
                                     <type>0</type>
@@ -939,7 +890,7 @@
                                 <graph_item>
                                     <sortorder>2</sortorder>
                                     <drawtype>0</drawtype>
-                                    <color>C80000</color>
+                                    <color>0000C8</color>
                                     <yaxisside>0</yaxisside>
                                     <calc_fnc>2</calc_fnc>
                                     <type>0</type>
@@ -970,8 +921,8 @@
                             <graph_items>
                                 <graph_item>
                                     <sortorder>0</sortorder>
-                                    <drawtype>0</drawtype>
-                                    <color>00C800</color>
+                                    <drawtype>2</drawtype>
+                                    <color>C80000</color>
                                     <yaxisside>0</yaxisside>
                                     <calc_fnc>2</calc_fnc>
                                     <type>0</type>
@@ -983,7 +934,7 @@
                                 <graph_item>
                                     <sortorder>1</sortorder>
                                     <drawtype>0</drawtype>
-                                    <color>0000C8</color>
+                                    <color>00C800</color>
                                     <yaxisside>0</yaxisside>
                                     <calc_fnc>2</calc_fnc>
                                     <type>0</type>
@@ -995,7 +946,7 @@
                                 <graph_item>
                                     <sortorder>2</sortorder>
                                     <drawtype>0</drawtype>
-                                    <color>C80000</color>
+                                    <color>0000C8</color>
                                     <yaxisside>0</yaxisside>
                                     <calc_fnc>2</calc_fnc>
                                     <type>0</type>
@@ -1026,38 +977,14 @@
                             <graph_items>
                                 <graph_item>
                                     <sortorder>0</sortorder>
-                                    <drawtype>0</drawtype>
-                                    <color>00C800</color>
-                                    <yaxisside>0</yaxisside>
-                                    <calc_fnc>2</calc_fnc>
-                                    <type>0</type>
-                                    <item>
-                                        <host>CPAN Zabbix-Check</host>
-                                        <key>cpan.zabbix.check.disk.ioutil[{#DEVNAME},total]</key>
-                                    </item>
-                                </graph_item>
-                                <graph_item>
-                                    <sortorder>1</sortorder>
-                                    <drawtype>0</drawtype>
-                                    <color>0000C8</color>
-                                    <yaxisside>0</yaxisside>
-                                    <calc_fnc>2</calc_fnc>
-                                    <type>0</type>
-                                    <item>
-                                        <host>CPAN Zabbix-Check</host>
-                                        <key>cpan.zabbix.check.disk.ioutil[{#DEVNAME},read]</key>
-                                    </item>
-                                </graph_item>
-                                <graph_item>
-                                    <sortorder>2</sortorder>
-                                    <drawtype>0</drawtype>
+                                    <drawtype>2</drawtype>
                                     <color>C80000</color>
                                     <yaxisside>0</yaxisside>
                                     <calc_fnc>2</calc_fnc>
                                     <type>0</type>
                                     <item>
                                         <host>CPAN Zabbix-Check</host>
-                                        <key>cpan.zabbix.check.disk.ioutil[{#DEVNAME},write]</key>
+                                        <key>cpan.zabbix.check.disk.ioutil[{#DEVNAME}]</key>
                                     </item>
                                 </graph_item>
                             </graph_items>
@@ -1678,6 +1605,10 @@
                 <macro>
                     <macro>{$ZC_TIME_ZONE}</macro>
                     <value>+0000</value>
+                </macro>
+                <macro>
+                    <macro>{$ZC_VERSION}</macro>
+                    <value>1.10</value>
                 </macro>
             </macros>
             <templates/>

--- a/conf/Template CPAN Zabbix-Check.xml
+++ b/conf/Template CPAN Zabbix-Check.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <zabbix_export>
-    <version>2.0</version>
-    <date>2016-12-23T18:57:26Z</date>
+    <version>3.0</version>
+    <date>2016-12-27T12:56:22Z</date>
     <groups>
         <group>
             <name>Templates</name>
@@ -35,49 +35,6 @@
                 </application>
             </applications>
             <items>
-                <item>
-                    <name>CPAN Zabbix-Check version</name>
-                    <type>0</type>
-                    <snmp_community/>
-                    <multiplier>0</multiplier>
-                    <snmp_oid/>
-                    <key>cpan.zabbix.check.version</key>
-                    <delay>60</delay>
-                    <history>7</history>
-                    <trends>365</trends>
-                    <status>0</status>
-                    <value_type>0</value_type>
-                    <allowed_hosts/>
-                    <units/>
-                    <delta>0</delta>
-                    <snmpv3_contextname/>
-                    <snmpv3_securityname/>
-                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                    <snmpv3_authpassphrase/>
-                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                    <snmpv3_privpassphrase/>
-                    <formula>1</formula>
-                    <delay_flex/>
-                    <params/>
-                    <ipmi_sensor/>
-                    <data_type>0</data_type>
-                    <authtype>0</authtype>
-                    <username/>
-                    <password/>
-                    <publickey/>
-                    <privatekey/>
-                    <port/>
-                    <description/>
-                    <inventory_link>0</inventory_link>
-                    <applications>
-                        <application>
-                            <name>General</name>
-                        </application>
-                    </applications>
-                    <valuemap/>
-                    <logtimefmt/>
-                </item>
                 <item>
                     <name>RabbitMQ installed</name>
                     <type>0</type>
@@ -302,7 +259,7 @@
                     <key>cpan.zabbix.check.systemd.system_status</key>
                     <delay>60</delay>
                     <history>7</history>
-                    <trends>365</trends>
+                    <trends>0</trends>
                     <status>0</status>
                     <value_type>4</value_type>
                     <allowed_hosts/>
@@ -431,7 +388,7 @@
                     <key>cpan.zabbix.check.time.zone</key>
                     <delay>60</delay>
                     <history>7</history>
-                    <trends>365</trends>
+                    <trends>0</trends>
                     <status>0</status>
                     <value_type>4</value_type>
                     <allowed_hosts/>
@@ -460,6 +417,49 @@
                     <applications>
                         <application>
                             <name>Time</name>
+                        </application>
+                    </applications>
+                    <valuemap/>
+                    <logtimefmt/>
+                </item>
+                <item>
+                    <name>CPAN Zabbix-Check version</name>
+                    <type>0</type>
+                    <snmp_community/>
+                    <multiplier>0</multiplier>
+                    <snmp_oid/>
+                    <key>cpan.zabbix.check.version</key>
+                    <delay>60</delay>
+                    <history>7</history>
+                    <trends>365</trends>
+                    <status>0</status>
+                    <value_type>0</value_type>
+                    <allowed_hosts/>
+                    <units/>
+                    <delta>0</delta>
+                    <snmpv3_contextname/>
+                    <snmpv3_securityname/>
+                    <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                    <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                    <snmpv3_authpassphrase/>
+                    <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                    <snmpv3_privpassphrase/>
+                    <formula>1</formula>
+                    <delay_flex/>
+                    <params/>
+                    <ipmi_sensor/>
+                    <data_type>0</data_type>
+                    <authtype>0</authtype>
+                    <username/>
+                    <password/>
+                    <publickey/>
+                    <privatekey/>
+                    <port/>
+                    <description/>
+                    <inventory_link>0</inventory_link>
+                    <applications>
+                        <application>
+                            <name>General</name>
                         </application>
                     </applications>
                     <valuemap/>
@@ -501,45 +501,6 @@
                     <description/>
                     <item_prototypes>
                         <item_prototype>
-                            <name>Disk {#DEVNAME} bps</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <multiplier>0</multiplier>
-                            <snmp_oid/>
-                            <key>cpan.zabbix.check.disk.bps[{#DEVNAME},total]</key>
-                            <delay>30</delay>
-                            <history>7</history>
-                            <trends>365</trends>
-                            <status>0</status>
-                            <value_type>0</value_type>
-                            <allowed_hosts/>
-                            <units>bps</units>
-                            <delta>0</delta>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <data_type>0</data_type>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
-                        </item_prototype>
-                        <item_prototype>
                             <name>Disk {#DEVNAME} bps read</name>
                             <type>0</type>
                             <snmp_community/>
@@ -577,6 +538,47 @@
                             <applications/>
                             <valuemap/>
                             <logtimefmt/>
+                            <application_prototypes/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>Disk {#DEVNAME} bps</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <multiplier>0</multiplier>
+                            <snmp_oid/>
+                            <key>cpan.zabbix.check.disk.bps[{#DEVNAME},total]</key>
+                            <delay>30</delay>
+                            <history>7</history>
+                            <trends>365</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units>bps</units>
+                            <delta>0</delta>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <formula>1</formula>
+                            <delay_flex/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <data_type>0</data_type>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <application_prototypes/>
                         </item_prototype>
                         <item_prototype>
                             <name>Disk {#DEVNAME} bps write</name>
@@ -616,45 +618,7 @@
                             <applications/>
                             <valuemap/>
                             <logtimefmt/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>Disk {#DEVNAME} I/O tps</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <multiplier>0</multiplier>
-                            <snmp_oid/>
-                            <key>cpan.zabbix.check.disk.iops[{#DEVNAME},total]</key>
-                            <delay>30</delay>
-                            <history>7</history>
-                            <trends>365</trends>
-                            <status>0</status>
-                            <value_type>0</value_type>
-                            <allowed_hosts/>
-                            <units>tps</units>
-                            <delta>0</delta>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <data_type>0</data_type>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
+                            <application_prototypes/>
                         </item_prototype>
                         <item_prototype>
                             <name>Disk {#DEVNAME} I/O tps read</name>
@@ -694,6 +658,47 @@
                             <applications/>
                             <valuemap/>
                             <logtimefmt/>
+                            <application_prototypes/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>Disk {#DEVNAME} I/O tps</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <multiplier>0</multiplier>
+                            <snmp_oid/>
+                            <key>cpan.zabbix.check.disk.iops[{#DEVNAME},total]</key>
+                            <delay>30</delay>
+                            <history>7</history>
+                            <trends>365</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units>tps</units>
+                            <delta>0</delta>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <formula>1</formula>
+                            <delay_flex/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <data_type>0</data_type>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <application_prototypes/>
                         </item_prototype>
                         <item_prototype>
                             <name>Disk {#DEVNAME} I/O tps write</name>
@@ -733,45 +738,7 @@
                             <applications/>
                             <valuemap/>
                             <logtimefmt/>
-                        </item_prototype>
-                        <item_prototype>
-                            <name>Disk {#DEVNAME} I/O Util</name>
-                            <type>0</type>
-                            <snmp_community/>
-                            <multiplier>0</multiplier>
-                            <snmp_oid/>
-                            <key>cpan.zabbix.check.disk.ioutil[{#DEVNAME},total]</key>
-                            <delay>30</delay>
-                            <history>7</history>
-                            <trends>365</trends>
-                            <status>0</status>
-                            <value_type>0</value_type>
-                            <allowed_hosts/>
-                            <units>%</units>
-                            <delta>0</delta>
-                            <snmpv3_contextname/>
-                            <snmpv3_securityname/>
-                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
-                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
-                            <snmpv3_authpassphrase/>
-                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
-                            <snmpv3_privpassphrase/>
-                            <formula>1</formula>
-                            <delay_flex/>
-                            <params/>
-                            <ipmi_sensor/>
-                            <data_type>0</data_type>
-                            <authtype>0</authtype>
-                            <username/>
-                            <password/>
-                            <publickey/>
-                            <privatekey/>
-                            <port/>
-                            <description/>
-                            <inventory_link>0</inventory_link>
-                            <applications/>
-                            <valuemap/>
-                            <logtimefmt/>
+                            <application_prototypes/>
                         </item_prototype>
                         <item_prototype>
                             <name>Disk {#DEVNAME} I/O Util read</name>
@@ -811,6 +778,47 @@
                             <applications/>
                             <valuemap/>
                             <logtimefmt/>
+                            <application_prototypes/>
+                        </item_prototype>
+                        <item_prototype>
+                            <name>Disk {#DEVNAME} I/O Util</name>
+                            <type>0</type>
+                            <snmp_community/>
+                            <multiplier>0</multiplier>
+                            <snmp_oid/>
+                            <key>cpan.zabbix.check.disk.ioutil[{#DEVNAME},total]</key>
+                            <delay>30</delay>
+                            <history>7</history>
+                            <trends>365</trends>
+                            <status>0</status>
+                            <value_type>0</value_type>
+                            <allowed_hosts/>
+                            <units>%</units>
+                            <delta>0</delta>
+                            <snmpv3_contextname/>
+                            <snmpv3_securityname/>
+                            <snmpv3_securitylevel>0</snmpv3_securitylevel>
+                            <snmpv3_authprotocol>0</snmpv3_authprotocol>
+                            <snmpv3_authpassphrase/>
+                            <snmpv3_privprotocol>0</snmpv3_privprotocol>
+                            <snmpv3_privpassphrase/>
+                            <formula>1</formula>
+                            <delay_flex/>
+                            <params/>
+                            <ipmi_sensor/>
+                            <data_type>0</data_type>
+                            <authtype>0</authtype>
+                            <username/>
+                            <password/>
+                            <publickey/>
+                            <privatekey/>
+                            <port/>
+                            <description/>
+                            <inventory_link>0</inventory_link>
+                            <applications/>
+                            <valuemap/>
+                            <logtimefmt/>
+                            <application_prototypes/>
                         </item_prototype>
                         <item_prototype>
                             <name>Disk {#DEVNAME} I/O Util write</name>
@@ -850,6 +858,7 @@
                             <applications/>
                             <valuemap/>
                             <logtimefmt/>
+                            <application_prototypes/>
                         </item_prototype>
                     </item_prototypes>
                     <trigger_prototypes>
@@ -861,6 +870,7 @@
                             <priority>1</priority>
                             <description/>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
                             <expression>{CPAN Zabbix-Check:cpan.zabbix.check.disk.ioutil[{#DEVNAME},total].min(1m)} &gt; 90</expression>
@@ -870,6 +880,7 @@
                             <priority>2</priority>
                             <description/>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
                             <expression>{CPAN Zabbix-Check:cpan.zabbix.check.disk.ioutil[{#DEVNAME},total].min(15m)} &gt; 90</expression>
@@ -879,6 +890,7 @@
                             <priority>3</priority>
                             <description/>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                     </trigger_prototypes>
                     <graph_prototypes>
@@ -1128,6 +1140,7 @@
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <application_prototypes/>
                         </item_prototype>
                         <item_prototype>
                             <name>RabbitMQ queue {#VHOST} {#QUEUE} total</name>
@@ -1171,6 +1184,7 @@
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <application_prototypes/>
                         </item_prototype>
                         <item_prototype>
                             <name>RabbitMQ queue {#VHOST} {#QUEUE} unacked</name>
@@ -1214,6 +1228,7 @@
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <application_prototypes/>
                         </item_prototype>
                     </item_prototypes>
                     <trigger_prototypes/>
@@ -1299,7 +1314,7 @@
                             <key>cpan.zabbix.check.supervisor.worker_status[{#NAME}]</key>
                             <delay>60</delay>
                             <history>7</history>
-                            <trends>365</trends>
+                            <trends>0</trends>
                             <status>0</status>
                             <value_type>4</value_type>
                             <allowed_hosts/>
@@ -1332,6 +1347,7 @@
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <application_prototypes/>
                         </item_prototype>
                     </item_prototypes>
                     <trigger_prototypes>
@@ -1343,6 +1359,7 @@
                             <priority>2</priority>
                             <description/>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
                             <expression>{CPAN Zabbix-Check:cpan.zabbix.check.supervisor.worker_status[{#NAME}].iregexp(^RUNNING, 5m)} = 0</expression>
@@ -1352,6 +1369,7 @@
                             <priority>3</priority>
                             <description/>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                     </trigger_prototypes>
                     <graph_prototypes/>
@@ -1432,6 +1450,7 @@
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <application_prototypes/>
                         </item_prototype>
                         <item_prototype>
                             <name>Systemd service {#NAME} availability for 1h</name>
@@ -1457,7 +1476,7 @@
                             <snmpv3_privpassphrase/>
                             <formula>1</formula>
                             <delay_flex/>
-                            <params>100*sum(&quot;cpan.zabbix.check.systemd.service_active[{#NAME}]&quot;, 3600)/60</params>
+                            <params>100*sum(&quot;cpan.zabbix.check.systemd.service_active[{#NAME}]&quot;, 3600)/count(&quot;cpan.zabbix.check.systemd.service_active[{#NAME}]&quot;, 3600)</params>
                             <ipmi_sensor/>
                             <data_type>0</data_type>
                             <authtype>0</authtype>
@@ -1475,6 +1494,7 @@
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <application_prototypes/>
                         </item_prototype>
                         <item_prototype>
                             <name>Systemd service {#NAME} availability for 24h</name>
@@ -1500,7 +1520,7 @@
                             <snmpv3_privpassphrase/>
                             <formula>1</formula>
                             <delay_flex/>
-                            <params>100*sum(&quot;cpan.zabbix.check.systemd.service_active[{#NAME}]&quot;, 86400)/1440</params>
+                            <params>100*sum(&quot;cpan.zabbix.check.systemd.service_active[{#NAME}]&quot;, 86400)/count(&quot;cpan.zabbix.check.systemd.service_active[{#NAME}]&quot;, 86400)</params>
                             <ipmi_sensor/>
                             <data_type>0</data_type>
                             <authtype>0</authtype>
@@ -1518,6 +1538,7 @@
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <application_prototypes/>
                         </item_prototype>
                         <item_prototype>
                             <name>Systemd service {#NAME} status</name>
@@ -1528,7 +1549,7 @@
                             <key>cpan.zabbix.check.systemd.service_status[{#NAME}]</key>
                             <delay>60</delay>
                             <history>7</history>
-                            <trends>365</trends>
+                            <trends>0</trends>
                             <status>0</status>
                             <value_type>4</value_type>
                             <allowed_hosts/>
@@ -1561,17 +1582,19 @@
                             </applications>
                             <valuemap/>
                             <logtimefmt/>
+                            <application_prototypes/>
                         </item_prototype>
                     </item_prototypes>
                     <trigger_prototypes>
                         <trigger_prototype>
-                            <expression>{CPAN Zabbix-Check:cpan.zabbix.check.systemd.service_availability_1h[{#NAME}].last()} &lt; {CPAN Zabbix-Check:cpan.zabbix.check.systemd.service_availability_24h[{#NAME}].last()}-10</expression>
+                            <expression>{CPAN Zabbix-Check:cpan.zabbix.check.systemd.service_availability_1h[{#NAME}].last()} &lt; {CPAN Zabbix-Check:cpan.zabbix.check.systemd.service_availability_24h[{#NAME}].last()}</expression>
                             <name>Systemd service {#NAME} availability low</name>
                             <url/>
                             <status>0</status>
                             <priority>2</priority>
                             <description/>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
                             <expression>{CPAN Zabbix-Check:cpan.zabbix.check.systemd.service_status[{#NAME}].iregexp(^failed)} &lt;&gt; 0</expression>
@@ -1581,6 +1604,7 @@
                             <priority>3</priority>
                             <description/>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                         <trigger_prototype>
                             <expression>{CPAN Zabbix-Check:cpan.zabbix.check.systemd.service_status[{#NAME}].diff()} &lt;&gt; 0</expression>
@@ -1590,6 +1614,7 @@
                             <priority>1</priority>
                             <description/>
                             <type>0</type>
+                            <dependencies/>
                         </trigger_prototype>
                     </trigger_prototypes>
                     <graph_prototypes>

--- a/conf/zabbix_agentd.conf
+++ b/conf/zabbix_agentd.conf
@@ -18,7 +18,7 @@ UserParameter=cpan.zabbix.check.rabbitmq.queue_status[*],/usr/bin/perl -MZabbix:
 
 UserParameter=cpan.zabbix.check.systemd.installed,/usr/bin/perl -MZabbix::Check::Systemd -e_installed
 UserParameter=cpan.zabbix.check.systemd.system_status,/usr/bin/perl -MZabbix::Check::Systemd -e_system_status
-UserParameter=cpan.zabbix.check.systemd.service_discovery,/usr/bin/perl -MZabbix::Check::Systemd -e_service_discovery
+UserParameter=cpan.zabbix.check.systemd.service_discovery[*],/usr/bin/perl -MZabbix::Check::Systemd -e_service_discovery -- $1
 UserParameter=cpan.zabbix.check.systemd.service_status[*],/usr/bin/perl -MZabbix::Check::Systemd -e_service_status -- $1
 
 UserParameter=cpan.zabbix.check.time.epoch,/usr/bin/perl -MZabbix::Check::Time -e_epoch

--- a/conf/zabbix_agentd.conf
+++ b/conf/zabbix_agentd.conf
@@ -1,26 +1,26 @@
 UserParameter=cpan.zabbix.check.version,/usr/bin/perl -MZabbix::Check -e_version
 
 UserParameter=cpan.zabbix.check.disk.discovery,/usr/bin/perl -MZabbix::Check::Disk -e_discovery
-UserParameter=cpan.zabbix.check.disk.bps[*],/usr/bin/perl -MZabbix::Check::Disk -e_bps $1 $2
-UserParameter=cpan.zabbix.check.disk.iops[*],/usr/bin/perl -MZabbix::Check::Disk -e_iops $1 $2
-UserParameter=cpan.zabbix.check.disk.ioutil[*],/usr/bin/perl -MZabbix::Check::Disk -e_ioutil $1 $2
+UserParameter=cpan.zabbix.check.disk.bps[*],/usr/bin/perl -MZabbix::Check::Disk -e_bps -- $1 $2
+UserParameter=cpan.zabbix.check.disk.iops[*],/usr/bin/perl -MZabbix::Check::Disk -e_iops -- $1 $2
+UserParameter=cpan.zabbix.check.disk.ioutil[*],/usr/bin/perl -MZabbix::Check::Disk -e_ioutil -- $1 $2
 
 UserParameter=cpan.zabbix.check.supervisor.installed,/usr/bin/perl -MZabbix::Check::Supervisor -e_installed
 UserParameter=cpan.zabbix.check.supervisor.running,/usr/bin/perl -MZabbix::Check::Supervisor -e_running
 UserParameter=cpan.zabbix.check.supervisor.worker_discovery,/usr/bin/perl -MZabbix::Check::Supervisor -e_worker_discovery
-UserParameter=cpan.zabbix.check.supervisor.worker_status[*],/usr/bin/perl -MZabbix::Check::Supervisor -e_worker_status $1
+UserParameter=cpan.zabbix.check.supervisor.worker_status[*],/usr/bin/perl -MZabbix::Check::Supervisor -e_worker_status -- $1
 
 UserParameter=cpan.zabbix.check.rabbitmq.installed,/usr/bin/perl -MZabbix::Check::RabbitMQ -e_installed
 UserParameter=cpan.zabbix.check.rabbitmq.running,/usr/bin/perl -MZabbix::Check::RabbitMQ -e_running
-UserParameter=cpan.zabbix.check.rabbitmq.vhost_discovery[*],/usr/bin/perl -MZabbix::Check::RabbitMQ -e_vhost_discovery $1
-UserParameter=cpan.zabbix.check.rabbitmq.queue_discovery[*],/usr/bin/perl -MZabbix::Check::RabbitMQ -e_queue_discovery $1
-UserParameter=cpan.zabbix.check.rabbitmq.queue_status[*],/usr/bin/perl -MZabbix::Check::RabbitMQ -e_queue_status $1 $2 $3
+UserParameter=cpan.zabbix.check.rabbitmq.vhost_discovery[*],/usr/bin/perl -MZabbix::Check::RabbitMQ -e_vhost_discovery -- $1
+UserParameter=cpan.zabbix.check.rabbitmq.queue_discovery[*],/usr/bin/perl -MZabbix::Check::RabbitMQ -e_queue_discovery -- $1
+UserParameter=cpan.zabbix.check.rabbitmq.queue_status[*],/usr/bin/perl -MZabbix::Check::RabbitMQ -e_queue_status -- $1 $2 $3
 
 UserParameter=cpan.zabbix.check.systemd.installed,/usr/bin/perl -MZabbix::Check::Systemd -e_installed
 UserParameter=cpan.zabbix.check.systemd.system_status,/usr/bin/perl -MZabbix::Check::Systemd -e_system_status
 UserParameter=cpan.zabbix.check.systemd.service_discovery,/usr/bin/perl -MZabbix::Check::Systemd -e_service_discovery
-UserParameter=cpan.zabbix.check.systemd.service_status[*],/usr/bin/perl -MZabbix::Check::Systemd -e_service_status $1
+UserParameter=cpan.zabbix.check.systemd.service_status[*],/usr/bin/perl -MZabbix::Check::Systemd -e_service_status -- $1
 
 UserParameter=cpan.zabbix.check.time.epoch,/usr/bin/perl -MZabbix::Check::Time -e_epoch
 UserParameter=cpan.zabbix.check.time.zone,/usr/bin/perl -MZabbix::Check::Time -e_zone
-UserParameter=cpan.zabbix.check.time.ntp_offset[*],/usr/bin/perl -MZabbix::Check::Time -e_ntp_offset $1 $2
+UserParameter=cpan.zabbix.check.time.ntp_offset[*],/usr/bin/perl -MZabbix::Check::Time -e_ntp_offset -- $1 $2

--- a/conf/zabbix_agentd.conf
+++ b/conf/zabbix_agentd.conf
@@ -3,7 +3,7 @@ UserParameter=cpan.zabbix.check.version,/usr/bin/perl -MZabbix::Check -e_version
 UserParameter=cpan.zabbix.check.disk.discovery,/usr/bin/perl -MZabbix::Check::Disk -e_discovery
 UserParameter=cpan.zabbix.check.disk.bps[*],/usr/bin/perl -MZabbix::Check::Disk -e_bps -- $1 $2
 UserParameter=cpan.zabbix.check.disk.iops[*],/usr/bin/perl -MZabbix::Check::Disk -e_iops -- $1 $2
-UserParameter=cpan.zabbix.check.disk.ioutil[*],/usr/bin/perl -MZabbix::Check::Disk -e_ioutil -- $1 $2
+UserParameter=cpan.zabbix.check.disk.ioutil[*],/usr/bin/perl -MZabbix::Check::Disk -e_ioutil -- $1
 
 UserParameter=cpan.zabbix.check.supervisor.installed,/usr/bin/perl -MZabbix::Check::Supervisor -e_installed
 UserParameter=cpan.zabbix.check.supervisor.running,/usr/bin/perl -MZabbix::Check::Supervisor -e_running

--- a/lib/Zabbix/Check.pm
+++ b/lib/Zabbix/Check.pm
@@ -22,9 +22,9 @@ gets Zabbix::Check version
 Zabbix check for disk
 
 	UserParameter=cpan.zabbix.check.disk.discovery,/usr/bin/perl -MZabbix::Check::Disk -e_discovery
-	UserParameter=cpan.zabbix.check.disk.bps[*],/usr/bin/perl -MZabbix::Check::Disk -e_bps $1 $2
-	UserParameter=cpan.zabbix.check.disk.iops[*],/usr/bin/perl -MZabbix::Check::Disk -e_iops $1 $2
-	UserParameter=cpan.zabbix.check.disk.ioutil[*],/usr/bin/perl -MZabbix::Check::Disk -e_ioutil $1 $2
+	UserParameter=cpan.zabbix.check.disk.bps[*],/usr/bin/perl -MZabbix::Check::Disk -e_bps -- $1 $2
+	UserParameter=cpan.zabbix.check.disk.iops[*],/usr/bin/perl -MZabbix::Check::Disk -e_iops -- $1 $2
+	UserParameter=cpan.zabbix.check.disk.ioutil[*],/usr/bin/perl -MZabbix::Check::Disk -e_ioutil -- $1 $2
 
 =head3 discovery
 
@@ -61,7 +61,7 @@ Zabbix check for Supervisor service
 	UserParameter=cpan.zabbix.check.supervisor.installed,/usr/bin/perl -MZabbix::Check::Supervisor -e_installed
 	UserParameter=cpan.zabbix.check.supervisor.running,/usr/bin/perl -MZabbix::Check::Supervisor -e_running
 	UserParameter=cpan.zabbix.check.supervisor.worker_discovery,/usr/bin/perl -MZabbix::Check::Supervisor -e_worker_discovery
-	UserParameter=cpan.zabbix.check.supervisor.worker_status[*],/usr/bin/perl -MZabbix::Check::Supervisor -e_worker_status $1
+	UserParameter=cpan.zabbix.check.supervisor.worker_status[*],/usr/bin/perl -MZabbix::Check::Supervisor -e_worker_status -- $1
 
 =head3 installed
 
@@ -87,9 +87,9 @@ Zabbix check for RabbitMQ service
 
 	UserParameter=cpan.zabbix.check.rabbitmq.installed,/usr/bin/perl -MZabbix::Check::RabbitMQ -e_installed
 	UserParameter=cpan.zabbix.check.rabbitmq.running,/usr/bin/perl -MZabbix::Check::RabbitMQ -e_running
-	UserParameter=cpan.zabbix.check.rabbitmq.vhost_discovery[*],/usr/bin/perl -MZabbix::Check::RabbitMQ -e_vhost_discovery $1
-	UserParameter=cpan.zabbix.check.rabbitmq.queue_discovery[*],/usr/bin/perl -MZabbix::Check::RabbitMQ -e_queue_discovery $1
-	UserParameter=cpan.zabbix.check.rabbitmq.queue_status[*],/usr/bin/perl -MZabbix::Check::RabbitMQ -e_queue_status $1 $2 $3
+	UserParameter=cpan.zabbix.check.rabbitmq.vhost_discovery[*],/usr/bin/perl -MZabbix::Check::RabbitMQ -e_vhost_discovery -- $1
+	UserParameter=cpan.zabbix.check.rabbitmq.queue_discovery[*],/usr/bin/perl -MZabbix::Check::RabbitMQ -e_queue_discovery -- $1
+	UserParameter=cpan.zabbix.check.rabbitmq.queue_status[*],/usr/bin/perl -MZabbix::Check::RabbitMQ -e_queue_status -- $1 $2 $3
 
 =head3 installed
 
@@ -128,7 +128,7 @@ Zabbix check for Systemd services
 	UserParameter=cpan.zabbix.check.systemd.installed,/usr/bin/perl -MZabbix::Check::Systemd -e_installed
 	UserParameter=cpan.zabbix.check.systemd.system_status,/usr/bin/perl -MZabbix::Check::Systemd -e_system_status
 	UserParameter=cpan.zabbix.check.systemd.service_discovery,/usr/bin/perl -MZabbix::Check::Systemd -e_service_discovery
-	UserParameter=cpan.zabbix.check.systemd.service_status[*],/usr/bin/perl -MZabbix::Check::Systemd -e_service_status $1
+	UserParameter=cpan.zabbix.check.systemd.service_status[*],/usr/bin/perl -MZabbix::Check::Systemd -e_service_status -- $1
 
 =head3 installed
 
@@ -154,7 +154,7 @@ Zabbix check for system time
 
 	UserParameter=cpan.zabbix.check.time.epoch,/usr/bin/perl -MZabbix::Check::Time -e_epoch
 	UserParameter=cpan.zabbix.check.time.zone,/usr/bin/perl -MZabbix::Check::Time -e_zone
-	UserParameter=cpan.zabbix.check.time.ntp_offset[*],/usr/bin/perl -MZabbix::Check::Time -e_ntp_offset $1 $2
+	UserParameter=cpan.zabbix.check.time.ntp_offset[*],/usr/bin/perl -MZabbix::Check::Time -e_ntp_offset -- $1 $2
 
 =head3 epoch
 

--- a/lib/Zabbix/Check.pm
+++ b/lib/Zabbix/Check.pm
@@ -125,7 +125,7 @@ Zabbix check for Systemd services
 
 	UserParameter=cpan.zabbix.check.systemd.installed,/usr/bin/perl -MZabbix::Check::Systemd -e_installed
 	UserParameter=cpan.zabbix.check.systemd.system_status,/usr/bin/perl -MZabbix::Check::Systemd -e_system_status
-	UserParameter=cpan.zabbix.check.systemd.service_discovery,/usr/bin/perl -MZabbix::Check::Systemd -e_service_discovery
+	UserParameter=cpan.zabbix.check.systemd.service_discovery[*],/usr/bin/perl -MZabbix::Check::Systemd -e_service_discovery -- $1
 	UserParameter=cpan.zabbix.check.systemd.service_status[*],/usr/bin/perl -MZabbix::Check::Systemd -e_service_status -- $1
 
 =head3 installed
@@ -139,6 +139,8 @@ gets Systemd system status: initializing | starting | running | degraded | maint
 =head3 service_discovery
 
 discovers Systemd enabled services
+
+$1: I<regex of service name, by default undefined>
 
 =head3 service_status $1
 

--- a/lib/Zabbix/Check.pm
+++ b/lib/Zabbix/Check.pm
@@ -1,7 +1,7 @@
 package Zabbix::Check;
 =head1 NAME
 
-Zabbix::Check - Zabbix Agent system and service checks
+Zabbix::Check - System and service checks for Zabbix
 
 =head1 VERSION
 
@@ -9,7 +9,7 @@ version 1.10
 
 =head1 SYNOPSIS
 
-System and service checks for Zabbix Agent
+System and service checks for Zabbix
 
 	UserParameter=cpan.zabbix.check.version,/usr/bin/perl -MZabbix::Check -e_version
 

--- a/lib/Zabbix/Check.pm
+++ b/lib/Zabbix/Check.pm
@@ -24,7 +24,7 @@ Zabbix check for disk
 	UserParameter=cpan.zabbix.check.disk.discovery,/usr/bin/perl -MZabbix::Check::Disk -e_discovery
 	UserParameter=cpan.zabbix.check.disk.bps[*],/usr/bin/perl -MZabbix::Check::Disk -e_bps -- $1 $2
 	UserParameter=cpan.zabbix.check.disk.iops[*],/usr/bin/perl -MZabbix::Check::Disk -e_iops -- $1 $2
-	UserParameter=cpan.zabbix.check.disk.ioutil[*],/usr/bin/perl -MZabbix::Check::Disk -e_ioutil -- $1 $2
+	UserParameter=cpan.zabbix.check.disk.ioutil[*],/usr/bin/perl -MZabbix::Check::Disk -e_ioutil -- $1
 
 =head3 discovery
 
@@ -51,8 +51,6 @@ $2: I<type: read|write|total>
 gets disk I/O utilization in percentage
 
 $1: I<device name, eg: sda, sdb1, dm-3, ...>
-
-$2: I<type: read|write|total>
 
 =head2 Supervisor
 

--- a/lib/Zabbix/Check.pm
+++ b/lib/Zabbix/Check.pm
@@ -5,7 +5,7 @@ Zabbix::Check - Zabbix Agent system and service checks
 
 =head1 VERSION
 
-version 1.09
+version 1.10
 
 =head1 SYNOPSIS
 
@@ -193,7 +193,7 @@ BEGIN
 {
 	require Exporter;
 	# set the version for version checking
-	our $VERSION     = '1.09';
+	our $VERSION     = '1.10';
 	# Inherit from Exporter to export functions and variables
 	our @ISA         = qw(Exporter);
 	# Functions and variables which are exported by default

--- a/lib/Zabbix/Check.pm
+++ b/lib/Zabbix/Check.pm
@@ -9,7 +9,7 @@ version 1.10
 
 =head1 SYNOPSIS
 
-Zabbix Agent system and service checks
+System and service checks for Zabbix Agent
 
 	UserParameter=cpan.zabbix.check.version,/usr/bin/perl -MZabbix::Check -e_version
 

--- a/lib/Zabbix/Check/Disk.pm
+++ b/lib/Zabbix/Check/Disk.pm
@@ -168,8 +168,7 @@ sub analyzeStats
 				eval { $oldStats = from_json($tmp) } if $tmp;
 				next unless not $tmp or $@;
 			}
-			unlink($tmpPath) if $now-$epoch > 2*60;
-			next;
+			next unless $now-$epoch > 2*60;
 		}
 		unlink($tmpPath);
 	}

--- a/lib/Zabbix/Check/Disk.pm
+++ b/lib/Zabbix/Check/Disk.pm
@@ -5,16 +5,16 @@ Zabbix::Check::Disk - Zabbix check for disk
 
 =head1 VERSION
 
-version 1.09
+version 1.10
 
 =head1 SYNOPSIS
 
 Zabbix check for disk
 
 	UserParameter=cpan.zabbix.check.disk.discovery,/usr/bin/perl -MZabbix::Check::Disk -e_discovery
-	UserParameter=cpan.zabbix.check.disk.bps[*],/usr/bin/perl -MZabbix::Check::Disk -e_bps $1 $2
-	UserParameter=cpan.zabbix.check.disk.iops[*],/usr/bin/perl -MZabbix::Check::Disk -e_iops $1 $2
-	UserParameter=cpan.zabbix.check.disk.ioutil[*],/usr/bin/perl -MZabbix::Check::Disk -e_ioutil $1 $2
+	UserParameter=cpan.zabbix.check.disk.bps[*],/usr/bin/perl -MZabbix::Check::Disk -e_bps -- $1 $2
+	UserParameter=cpan.zabbix.check.disk.iops[*],/usr/bin/perl -MZabbix::Check::Disk -e_iops -- $1 $2
+	UserParameter=cpan.zabbix.check.disk.ioutil[*],/usr/bin/perl -MZabbix::Check::Disk -e_ioutil -- $1 $2
 
 =head3 discovery
 
@@ -60,7 +60,7 @@ BEGIN
 {
 	require Exporter;
 	# set the version for version checking
-	our $VERSION     = '1.09';
+	our $VERSION     = '1.10';
 	# Inherit from Exporter to export functions and variables
 	our @ISA         = qw(Exporter);
 	# Functions and variables which are exported by default

--- a/lib/Zabbix/Check/Disk.pm
+++ b/lib/Zabbix/Check/Disk.pm
@@ -148,7 +148,7 @@ sub analyzeStats
 	my $now = time();
 	my $stats;
 	my $oldStats;
-	my $tmpPrefix = "/tmp/".__PACKAGE__ =~ s/\Q::\E/-/gr.".analyzeStats.";
+	my $tmpPrefix = "/tmp/".(caller(0))[3] =~ s/\Q::\E/-/gr.",stats,";
 	for my $tmpPath (sort {$b cmp $a} glob("$tmpPrefix*"))
 	{
 		if (my ($epoch, $pid) = $tmpPath =~ /^\Q$tmpPrefix\E(\d*)\.(\d*)/)

--- a/lib/Zabbix/Check/RabbitMQ.pm
+++ b/lib/Zabbix/Check/RabbitMQ.pm
@@ -5,7 +5,7 @@ Zabbix::Check::RabbitMQ - Zabbix check for RabbitMQ service
 
 =head1 VERSION
 
-version 1.09
+version 1.10
 
 =head1 SYNOPSIS
 
@@ -13,9 +13,9 @@ Zabbix check for RabbitMQ service
 
 	UserParameter=cpan.zabbix.check.rabbitmq.installed,/usr/bin/perl -MZabbix::Check::RabbitMQ -e_installed
 	UserParameter=cpan.zabbix.check.rabbitmq.running,/usr/bin/perl -MZabbix::Check::RabbitMQ -e_running
-	UserParameter=cpan.zabbix.check.rabbitmq.vhost_discovery[*],/usr/bin/perl -MZabbix::Check::RabbitMQ -e_vhost_discovery $1
-	UserParameter=cpan.zabbix.check.rabbitmq.queue_discovery[*],/usr/bin/perl -MZabbix::Check::RabbitMQ -e_queue_discovery $1
-	UserParameter=cpan.zabbix.check.rabbitmq.queue_status[*],/usr/bin/perl -MZabbix::Check::RabbitMQ -e_queue_status $1 $2 $3
+	UserParameter=cpan.zabbix.check.rabbitmq.vhost_discovery[*],/usr/bin/perl -MZabbix::Check::RabbitMQ -e_vhost_discovery -- $1
+	UserParameter=cpan.zabbix.check.rabbitmq.queue_discovery[*],/usr/bin/perl -MZabbix::Check::RabbitMQ -e_queue_discovery -- $1
+	UserParameter=cpan.zabbix.check.rabbitmq.queue_status[*],/usr/bin/perl -MZabbix::Check::RabbitMQ -e_queue_status -- $1 $2 $3
 
 =head3 installed
 
@@ -62,7 +62,7 @@ BEGIN
 {
 	require Exporter;
 	# set the version for version checking
-	our $VERSION     = '1.09';
+	our $VERSION     = '1.10';
 	# Inherit from Exporter to export functions and variables
 	our @ISA         = qw(Exporter);
 	# Functions and variables which are exported by default
@@ -80,7 +80,7 @@ sub getVhosts
 	return unless $rabbitmqctl;
 	my ($expiry) = @_;
 	$expiry = -1 unless defined($expiry);
-	my $result = cache((caller(0))[3], $expiry, sub
+	my $result = fileCache("all", $expiry, sub
 	{
 		my $result = {};
 		my $first = 1;
@@ -107,7 +107,7 @@ sub getQueues
 	my ($vhost, $expiry) = @_;
 	my $vhostS = shellmeta($vhost);
 	$expiry = -1 unless defined($expiry);
-	my $result = cache((caller(0))[3].",$vhost", $expiry, sub
+	my $result = fileCache($vhost, $expiry, sub
 	{
 		my $result = {};
 		my $first = 1;

--- a/lib/Zabbix/Check/RabbitMQ.pm
+++ b/lib/Zabbix/Check/RabbitMQ.pm
@@ -97,7 +97,6 @@ sub getVhosts
 		}
 		return $result;
 	});
-	$result = {} unless $result;
 	return $result;
 }
 
@@ -124,7 +123,6 @@ sub getQueues
 		}
 		return $result;
 	});
-	$result = {} unless $result;
 	return $result;
 }
 

--- a/lib/Zabbix/Check/Supervisor.pm
+++ b/lib/Zabbix/Check/Supervisor.pm
@@ -66,7 +66,7 @@ our ($supervisord) = whereisBin('supervisord');
 sub getStatuses
 {
 	return unless $supervisorctl;
-	my $result = fileCache("all", 15, sub
+	my $result = fileCache("all", 30, sub
 	{
 		my $result = {};
 		for (`$supervisorctl status 2>/dev/null`)

--- a/lib/Zabbix/Check/Supervisor.pm
+++ b/lib/Zabbix/Check/Supervisor.pm
@@ -5,7 +5,7 @@ Zabbix::Check::Supervisor - Zabbix check for Supervisor service
 
 =head1 VERSION
 
-version 1.08
+version 1.10
 
 =head1 SYNOPSIS
 
@@ -14,7 +14,7 @@ Zabbix check for Supervisor service
 	UserParameter=cpan.zabbix.check.supervisor.installed,/usr/bin/perl -MZabbix::Check::Supervisor -e_installed
 	UserParameter=cpan.zabbix.check.supervisor.running,/usr/bin/perl -MZabbix::Check::Supervisor -e_running
 	UserParameter=cpan.zabbix.check.supervisor.worker_discovery,/usr/bin/perl -MZabbix::Check::Supervisor -e_worker_discovery
-	UserParameter=cpan.zabbix.check.supervisor.worker_status[*],/usr/bin/perl -MZabbix::Check::Supervisor -e_worker_status $1
+	UserParameter=cpan.zabbix.check.supervisor.worker_status[*],/usr/bin/perl -MZabbix::Check::Supervisor -e_worker_status -- $1
 
 =head3 installed
 
@@ -49,7 +49,7 @@ BEGIN
 {
 	require Exporter;
 	# set the version for version checking
-	our $VERSION     = '1.08';
+	our $VERSION     = '1.10';
 	# Inherit from Exporter to export functions and variables
 	our @ISA         = qw(Exporter);
 	# Functions and variables which are exported by default

--- a/lib/Zabbix/Check/Supervisor.pm
+++ b/lib/Zabbix/Check/Supervisor.pm
@@ -66,13 +66,17 @@ our ($supervisord) = whereisBin('supervisord');
 sub getStatuses
 {
 	return unless $supervisorctl;
-	my $result = {};
-	for (`$supervisorctl status 2>/dev/null`)
+	my $result = fileCache("all", 15, sub
 	{
-		chomp;
-		my ($name, $status) = /^(\S+)\s+(\S+)\s*/;
-		$result->{$name} = $status;
-	}
+		my $result = {};
+		for (`$supervisorctl status 2>/dev/null`)
+		{
+			chomp;
+			my ($name, $status) = /^(\S+)\s+(\S+)\s*/;
+			$result->{$name} = $status;
+		}
+		return $result;
+	});
 	return $result;
 }
 

--- a/lib/Zabbix/Check/Supervisor.pm
+++ b/lib/Zabbix/Check/Supervisor.pm
@@ -107,15 +107,9 @@ sub _worker_status
 {
 	my ($name) = map(zbxDecode($_), @ARGV);
 	return unless $name;
-	my $nameS = shellmeta($name);
 	my $result = "";
-	my $line = `$supervisorctl status \"$nameS\" 2>/dev/null` if $supervisorctl;
-	if ($line)
-	{
-		chomp $line;
-		my ($name, $status) = $line =~/^(\S+)\s+(\S+)\s*/;
-		$result = $status if $status;
-	}
+	my $statuses = getStatuses();
+	$result = $statuses->{$name} if $statuses->{$name};
 	print $result;
 	return $result;	
 }

--- a/lib/Zabbix/Check/Systemd.pm
+++ b/lib/Zabbix/Check/Systemd.pm
@@ -5,7 +5,7 @@ Zabbix::Check::Systemd - Zabbix check for Systemd services
 
 =head1 VERSION
 
-version 1.06
+version 1.10
 
 =head1 SYNOPSIS
 
@@ -14,7 +14,7 @@ Zabbix check for Systemd services
 	UserParameter=cpan.zabbix.check.systemd.installed,/usr/bin/perl -MZabbix::Check::Systemd -e_installed
 	UserParameter=cpan.zabbix.check.systemd.system_status,/usr/bin/perl -MZabbix::Check::Systemd -e_system_status
 	UserParameter=cpan.zabbix.check.systemd.service_discovery,/usr/bin/perl -MZabbix::Check::Systemd -e_service_discovery
-	UserParameter=cpan.zabbix.check.systemd.service_status[*],/usr/bin/perl -MZabbix::Check::Systemd -e_service_status $1
+	UserParameter=cpan.zabbix.check.systemd.service_status[*],/usr/bin/perl -MZabbix::Check::Systemd -e_service_status -- $1
 
 =head3 installed
 
@@ -49,7 +49,7 @@ BEGIN
 {
 	require Exporter;
 	# set the version for version checking
-	our $VERSION     = '1.06';
+	our $VERSION     = '1.10';
 	# Inherit from Exporter to export functions and variables
 	our @ISA         = qw(Exporter);
 	# Functions and variables which are exported by default

--- a/lib/Zabbix/Check/Time.pm
+++ b/lib/Zabbix/Check/Time.pm
@@ -5,7 +5,7 @@ Zabbix::Check::Systemd - Zabbix check for system time
 
 =head1 VERSION
 
-version 1.09
+version 1.10
 
 =head1 SYNOPSIS
 
@@ -13,7 +13,7 @@ Zabbix check for system time
 
 	UserParameter=cpan.zabbix.check.time.epoch,/usr/bin/perl -MZabbix::Check::Time -e_epoch
 	UserParameter=cpan.zabbix.check.time.zone,/usr/bin/perl -MZabbix::Check::Time -e_zone
-	UserParameter=cpan.zabbix.check.time.ntp_offset[*],/usr/bin/perl -MZabbix::Check::Time -e_ntp_offset $1 $2
+	UserParameter=cpan.zabbix.check.time.ntp_offset[*],/usr/bin/perl -MZabbix::Check::Time -e_ntp_offset -- $1 $2
 
 =head3 epoch
 
@@ -48,7 +48,7 @@ BEGIN
 {
 	require Exporter;
 	# set the version for version checking
-	our $VERSION     = '1.09';
+	our $VERSION     = '1.10';
 	# Inherit from Exporter to export functions and variables
 	our @ISA         = qw(Exporter);
 	# Functions and variables which are exported by default


### PR DESCRIPTION
- Usage of Lazy::Utils::fileCache instead of cache function
- Perl arguement fix ( -- ) in configuration, readme, pod
- Supervisor worker status fix for "no such ..." result for undefined workers
- Added file cache in Supervisor getStatuses
- Fix and changes for disk ioutil